### PR TITLE
fix typo

### DIFF
--- a/grocery-list/win10-AD-ADFS/azuredeploy.json
+++ b/grocery-list/win10-AD-ADFS/azuredeploy.json
@@ -158,7 +158,7 @@
             },
             "defaultValue": "azsentinel.local"
         },
-        "setSecurityCollectionTier": {
+        "SecurityCollectionTier": {
             "type": "string",
             "metadata": {
                 "description": "Tier for gathering Windows Security Events."
@@ -272,8 +272,8 @@
                             "SecurityInsightsSecurityEventCollectionConfiguration"
                         ]
                     },
-                    "setSecurityCollectionTier": {
-                        "value": "[parameters('setSecurityCollectionTier')]"
+                    "SecurityCollectionTier": {
+                        "value": "[parameters('SecurityCollectionTier')]"
                     }
                 }
             }


### PR DESCRIPTION
fix name  of variable from setSecurityCollectionTier to SecurityCollectionTier.
This will fix deployment error:
`Deployment template validation failed: 'The template parameters 'setSecurityCollectionTier' in the parameters file are not valid; they are not present in the original template and can therefore not be provided at deployment time.`