### PR TITLE
fix Blacksmith Azure-EventHub directory reference

### DIFF
--- a/grocery-list/custom-log-pipeline/azuredeploy.json
+++ b/grocery-list/custom-log-pipeline/azuredeploy.json
@@ -222,7 +222,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "[uri(variables('artifactsBlacksmithLocation'), 'templates/azure/EventHub/azuredeploy.json')]",
+                    "uri": "[uri(variables('artifactsBlacksmithLocation'), 'templates/azure/Azure-EventHub/azuredeploy.json')]",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {


### PR DESCRIPTION
the directory in the Blacksmith repo was renamed from EventHub to Azure-EventHub